### PR TITLE
Fix lazy load crash async

### DIFF
--- a/docs_src/async_sql_databases/sql_app/models.py
+++ b/docs_src/async_sql_databases/sql_app/models.py
@@ -12,7 +12,7 @@ class User(Base):
     hashed_password = Column(String)
     is_active = Column(Boolean, default=True)
 
-    items = relationship("Item", back_populates="owner")
+    items = relationship("Item", back_populates="owner", lazy='selectin')
 
 
 class Item(Base):
@@ -23,4 +23,4 @@ class Item(Base):
     description = Column(String, index=True)
     owner_id = Column(Integer, ForeignKey("users.id"))
 
-    owner = relationship("User", back_populates="items")
+    owner = relationship("User", back_populates="items", lazy='selectin')


### PR DESCRIPTION
Due to lazy load make async not work, I change the mode from lazy(select) loading to select in loading https://docs.sqlalchemy.org/en/14/orm/loading_relationships.html

In this way, there is no need to query again.  But at the same time, if we don't need relationships, it is a waste.

https://docs.sqlalchemy.org/en/14/orm/extensions/asyncio.html#synopsis-orm

And I didn't think there is other ways to solve this problem currently.